### PR TITLE
fix: adjust filter on svdb merged file

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -55,7 +55,7 @@ bcftools_softfilter_scramble:
   extra: "-s LowQual "
 
 bcftools_view_svdb:
-  extra: "-f 'PASS'"
+  extra: "-e 'FILTER~\"LowQual\"'"
 
 bwa_mem:
   container: "docker://hydragenetics/bwa:0.7.15"


### PR DESCRIPTION
This excludes Melt calls that are marked LowQual, but keeps the rest that can have PASS or another filter (e.g., hDP) that we don't want to remove in exome melt calling

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated variant filtering so records marked **LowQual** are now included in the relevant output instead of being limited to only passing records.
  * Improved consistency in which SVDB results are shown downstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->